### PR TITLE
Updated code to be compliant with Zig 0.12

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
     _ = b.addModule("zzmq", .{
-        .source_file = .{ .path = "src/zzmq.zig" },
+        .root_source_file = .{ .path = "src/zzmq.zig" },
     });
 
     const lib_test = b.addTest(.{

--- a/examples/dealer_rep_client/build.zig
+++ b/examples/dealer_rep_client/build.zig
@@ -29,7 +29,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    exe.addModule("zzmq", zzmq.module("zzmq"));
+    exe.root_module.addImport("zzmq", zzmq.module("zzmq"));
 
     exe.linkSystemLibrary("zmq");
     exe.linkLibC();

--- a/examples/dealer_rep_server/build.zig
+++ b/examples/dealer_rep_server/build.zig
@@ -29,7 +29,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    exe.addModule("zzmq", zzmq.module("zzmq"));
+    exe.root_module.addImport("zzmq", zzmq.module("zzmq"));
 
     exe.linkSystemLibrary("zmq");
     exe.linkLibC();

--- a/examples/hello_world_client/build.zig
+++ b/examples/hello_world_client/build.zig
@@ -29,7 +29,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    exe.addModule("zzmq", zzmq.module("zzmq"));
+    exe.root_module.addImport("zzmq", zzmq.module("zzmq"));
 
     exe.linkSystemLibrary("zmq");
     exe.linkLibC();

--- a/examples/hello_world_server/build.zig
+++ b/examples/hello_world_server/build.zig
@@ -29,7 +29,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    exe.addModule("zzmq", zzmq.module("zzmq"));
+    exe.root_module.addImport("zzmq", zzmq.module("zzmq"));
 
     exe.linkSystemLibrary("zmq");
     exe.linkLibC();

--- a/src/classes/zcontext.zig
+++ b/src/classes/zcontext.zig
@@ -25,7 +25,7 @@ pub const ZContext = struct {
         }
 
         // try creating the socket, early
-        var s = c.zmq_ctx_new() orelse {
+        const s = c.zmq_ctx_new() orelse {
             switch (c.zmq_errno()) {
                 c.EMFILE => return error.MaxOpenFilesExceeded,
                 else => return error.ContextCreateFailed,

--- a/src/classes/zmessage.zig
+++ b/src/classes/zmessage.zig
@@ -91,7 +91,7 @@ pub const ZMessage = struct {
         switch (self.impl_) {
             .Internal => return try self.impl_.Internal.allocExternal(),
             .External => {
-                var cpy = self.impl_.External;
+                const cpy = self.impl_.External;
 
                 self.impl_.External.msgOwned_ = false; // ownership moved away
 
@@ -177,11 +177,11 @@ const ZMessageInternal = struct {
     }
 
     fn refAdd(self: *ZMessageInternal) void {
-        _ = @atomicRmw(usize, &self.refCounter_, .Add, 1, .SeqCst);
+        _ = @atomicRmw(usize, &self.refCounter_, .Add, 1, .seq_cst);
     }
 
     fn refRelease(self: *ZMessageInternal) void {
-        const prev = @atomicRmw(usize, &self.refCounter_, .Sub, 1, .SeqCst);
+        const prev = @atomicRmw(usize, &self.refCounter_, .Sub, 1, .seq_cst);
 
         if (prev == 1) { // it's now zero
             if (self.allocator_) |a| {

--- a/src/classes/zsocket.zig
+++ b/src/classes/zsocket.zig
@@ -266,7 +266,7 @@ pub const ZSocket = struct {
 
     pub fn init(socketType: ZSocketType, context: *zcontext.ZContext) !*ZSocket {
         // try creating the socket, early
-        var s = c.zmq_socket(context.ctx_, @intFromEnum(socketType)) orelse return error.SocketCreateFailed;
+        const s = c.zmq_socket(context.ctx_, @intFromEnum(socketType)) orelse return error.SocketCreateFailed;
         errdefer _ = c.zmq_close(s);
 
         // create the managed object

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,30 +1,11 @@
 FROM alpine:3.19 as builder
 
-# Install necessary tools for building musl
-RUN apk add --no-cache clang make
-
-# Download musl source code
-RUN wget https://musl.libc.org/releases/musl-1.2.4.tar.gz
-
-# Extract the source code
-RUN tar -xzvf musl-1.2.4.tar.gz
-
-# Navigate into the musl directory
-WORKDIR /musl-1.2.4
-
-# Configure, build, and install musl
-RUN ./configure && make && make install
-
-# Cleanup
-WORKDIR /
-RUN rm -rf /musl-1.2.4 musl-1.2.4.tar.gz
-
 # install Zig 0.12 from Alpine edge repo: https://pkgs.alpinelinux.org/package/edge/testing/x86_64/zig
-RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
-RUN apk add --no-cache zig@testing~=0.12.0
+RUN echo "@edge-community https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+RUN apk add --no-cache zig@edge-community~=0.12.0
 
 # install dependencies
-RUN apk add --no-cache zeromq-dev
+RUN apk add --no-cache zeromq-dev clang
 
 COPY . /build/
 

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,8 +1,27 @@
 FROM alpine:3.19 as builder
 
-# install Zig 0.11 from Alpine edge repo: https://pkgs.alpinelinux.org/package/edge/testing/x86_64/zig
+# Install necessary tools for building musl
+RUN apk add --no-cache clang make
+
+# Download musl source code
+RUN wget https://musl.libc.org/releases/musl-1.2.4.tar.gz
+
+# Extract the source code
+RUN tar -xzvf musl-1.2.4.tar.gz
+
+# Navigate into the musl directory
+WORKDIR /musl-1.2.4
+
+# Configure, build, and install musl
+RUN ./configure && make && make install
+
+# Cleanup
+WORKDIR /
+RUN rm -rf /musl-1.2.4 musl-1.2.4.tar.gz
+
+# install Zig 0.12 from Alpine edge repo: https://pkgs.alpinelinux.org/package/edge/testing/x86_64/zig
 RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
-RUN apk add --no-cache zig@testing~=0.11.0
+RUN apk add --no-cache zig@testing~=0.12.0
 
 # install dependencies
 RUN apk add --no-cache zeromq-dev
@@ -14,8 +33,6 @@ WORKDIR /build
 RUN zig build test -Doptimize=ReleaseFast --summary all
 
 RUN touch /var/touched # dummy build output
-
-
 
 # empty result image
 FROM scratch


### PR DESCRIPTION
This pull request makes necessary changes to get the codebase compliant with Zig 0.12. The test.Dockerfile builds musl 1.2.4 because Alpine Linux is using musl 1.2.5 which is incompatible with Zig 0.12. I wasn't able to find a simpler way of getting musl 1.2.4 in the testing environment.
