### PR TITLE
Supports zig 0.13.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,15 +4,26 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("zzmq", .{
-        .root_source_file = .{ .path = "src/zzmq.zig" },
+    const mod_zmq = b.addModule("zzmq", .{
+        .root_source_file = b.path("src/zzmq.zig"),
     });
 
+    const prefix = b.option([]const u8, "prefix", "zmq installed path");
+    
+    if (prefix) |p| {
+        mod_zmq.addIncludePath(.{ .cwd_relative = b.pathResolve(&[_][]const u8 { p, "zmq/include" }) } );
+    }
+
     const lib_test = b.addTest(.{
-        .root_source_file = .{ .path = "src/zzmq.zig" },
+        .root_source_file = b.path("src/zzmq.zig"),
         .target = target,
         .optimize = optimize,
     });
+
+    if (prefix) |p| {
+        lib_test.addIncludePath(.{ .cwd_relative = b.pathResolve(&[_][]const u8 { p, "zmq/include" }) } );
+        lib_test.addLibraryPath(.{ .cwd_relative = b.pathResolve(&[_][]const u8 { p, "zmq/lib" }) });
+    }
 
     lib_test.linkSystemLibrary("zmq");
     lib_test.linkLibC();


### PR DESCRIPTION
In zig 0.13.0, build configration is changed.
e.g. the `path` field of `std.Build.LazyPath` is deprecated, and so on...

This PR has dealt with following problem:

* change `path` field of `std.Build.LazyPath to `std.Build.path` method.

Additionally, a installed path of libzmq (prefix) as the project specific option.

If libzmq is installed on system, it can pass prefix.

```
zig build -Dprefix=<PATH> test
```
